### PR TITLE
Adds `getCurrentRoute` method to php doc for IDE Auto completion

### DIFF
--- a/src/Illuminate/Support/Facades/Route.php
+++ b/src/Illuminate/Support/Facades/Route.php
@@ -35,6 +35,7 @@ namespace Illuminate\Support\Facades;
  * @method static \Illuminate\Routing\Route current()
  * @method static string|null currentRouteName()
  * @method static string|null currentRouteAction()
+ * @method static \Illuminate\Routing\Route getCurrentRoute()
  *
  * @see \Illuminate\Routing\Router
  */


### PR DESCRIPTION
This PR adds the `getCurrentRoute` method of `\Illuminate\Routing\Router` class to the `Route` facade php doc block, in order to provide IDE auto completion.